### PR TITLE
Upstream Update

### DIFF
--- a/.github/workflows/_meta-build.yaml
+++ b/.github/workflows/_meta-build.yaml
@@ -102,7 +102,7 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
       - name: Build multi-arch Container Image
-        uses: docker/build-push-action@v6.6.1
+        uses: docker/build-push-action@v6.7.0
         with:
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |-

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@coreui/vue": "2.1.2",
         "@johmun/vue-tags-input": "2.1.0",
         "@monaco-editor/loader": "1.4.0",
-        "axios": "1.6.8",
+        "axios": "1.7.4",
         "bootstrap": "4.6.2",
         "bootstrap-table": "1.22.4",
         "bootstrap-vue": "2.23.1",
@@ -5275,9 +5275,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -23768,9 +23768,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@coreui/vue": "2.1.2",
     "@johmun/vue-tags-input": "2.1.0",
     "@monaco-editor/loader": "1.4.0",
-    "axios": "1.6.8",
+    "axios": "1.7.4",
     "bootstrap": "4.6.2",
     "bootstrap-table": "1.22.4",
     "bootstrap-vue": "2.23.1",

--- a/src/views/administration/notifications/Alerts.vue
+++ b/src/views/administration/notifications/Alerts.vue
@@ -188,6 +188,7 @@ export default {
                           <div class="list-group-item"><b-form-checkbox value="BOM_CONSUMED">BOM_CONSUMED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="BOM_PROCESSED">BOM_PROCESSED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="BOM_PROCESSING_FAILED">BOM_PROCESSING_FAILED</b-form-checkbox></div>
+                          <div class="list-group-item"><b-form-checkbox value="BOM_VALIDATION_FAILED">BOM_VALIDATION_FAILED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="VEX_CONSUMED">VEX_CONSUMED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="VEX_PROCESSED">VEX_PROCESSED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="POLICY_VIOLATION">POLICY_VIOLATION</b-form-checkbox></div>


### PR DESCRIPTION
- **Add BOM_VALIDATION_FAILED To Notification Group**
- **build(deps): bump docker/build-push-action from 6.6.1 to 6.7.0**
- **build(deps): bump axios from 1.6.8 to 1.7.4**

### Description

Synced with upstream

### Addressed Issue

May have fixed workflow issues patched in upstream.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
